### PR TITLE
Added configuration for filtering arrivals by route names

### DIFF
--- a/tfi-gtfs/tfi-gtfs-card.js
+++ b/tfi-gtfs/tfi-gtfs-card.js
@@ -49,6 +49,7 @@ class TfiGtfsCardEditor extends LitElement {
                 },
                 {name: "apiUrl", label: "API URL", selector: { text: {type: 'url'} }, required: false},
                 {name: "stopNumber", label: "Stop Number", selector: { text: {} }, required: false},
+                {name: "filterRoutes", label: "Filter by route names (comma separeted)", selector: { text: {type: 'string'} }, required: false },
                 {name: "refreshInterval", label: "Refresh Interval (seconds)", selector: { text: {type: 'number'} } },
                 {name: "maxArrivals", label: "Maximum number of arrivals to show", selector: { text: {type: 'number'} } },
             ]}
@@ -105,14 +106,26 @@ class TfiGtfsCard extends LitElement {
     }
     getArrivals() {
         if(this.config.stopEntity) {
+            if(this.config.filterRoutes) {
+                return this.filterArrivals(this.hass.states[this.config.stopEntity].attributes.arrivals, this.config.filterRoutes)
+            }
             return this.hass.states[this.config.stopEntity].attributes.arrivals;
         }
         else if(this.data) {
+            if(this.config.filterRoutes) {
+                return this.filterArrivals(this.data[this.config.stopNumber].arrivals, this.config.filterRoutes)
+            }
             return this.data[this.config.stopNumber].arrivals;
         }
         else {
             return [];
         }
+    }
+    filterArrivals(arrivals, routeNumbers) {
+        // Convert the comma-separated routeNumbers string into an array
+        const routeNumberArray = routeNumbers.split(',').map(route => route.trim());
+        // Filter the arrivals array based on the routeNumberArray
+        return arrivals.filter(arrival => routeNumberArray.includes(arrival.route));
     }
 
     getStopName() { 


### PR DESCRIPTION
This pull request introduces a new configuration option `filterRoutes` to filter bus arrivals based on route names. The following changes were made:
- Added `filterRoutes` configuration in the UI schema.
- Implemented filtering logic in `getArrivals()` and `filterArrivals()` methods.

With this feature, users can now specify a comma-separated list of route names to display only the selected routes on the card.
Example display for just one route:
![image](https://github.com/user-attachments/assets/5dc3bee9-f9c7-4b53-9e51-71432a9e8c24)

