### PR TITLE
Added configuration to overwrite bus stop name in the UI

### DIFF
--- a/tfi-gtfs/tfi-gtfs-card.js
+++ b/tfi-gtfs/tfi-gtfs-card.js
@@ -49,6 +49,7 @@ class TfiGtfsCardEditor extends LitElement {
                 },
                 {name: "apiUrl", label: "API URL", selector: { text: {type: 'url'} }, required: false},
                 {name: "stopNumber", label: "Stop Number", selector: { text: {} }, required: false},
+                {name: "overwriteStopName", label: "Overwrite stop name in the UI", selector: { text: {} }, required: false},
                 {name: "refreshInterval", label: "Refresh Interval (seconds)", selector: { text: {type: 'number'} } },
                 {name: "maxArrivals", label: "Maximum number of arrivals to show", selector: { text: {type: 'number'} } },
             ]}
@@ -117,6 +118,9 @@ class TfiGtfsCard extends LitElement {
 
     getStopName() { 
         if(this.config.stopEntity) {
+            if(this.config.overwriteStopName) {
+                return this.config.overwriteStopName;
+            }
             return this.hass.states[this.config.stopEntity].attributes.stop_name;
         }
         else if(this.data) {


### PR DESCRIPTION
This pull request introduces a new configuration option `overwriteStopName` to allow users to overwrite the bus stop name displayed in the UI. The following changes were made:
- Added `overwriteStopName` configuration in the UI schema.
- Implemented logic in `getStopName()` method to use the overwriteStopName if provided.

With this feature, users can now specify a custom name for the bus stop, which will be displayed in the UI instead of the default name.
Example:
![image](https://github.com/user-attachments/assets/8605aca9-4b36-4095-86aa-c3376453bca3)
