### PR TITLE
Fix issue with missing DEFAULT_ICON variable

### DIFF
--- a/tfi-gtfs/tfi-gtfs-card.js
+++ b/tfi-gtfs/tfi-gtfs-card.js
@@ -5,6 +5,7 @@ const DEFAULT_STOP_NUMBER = "";
 const DEFAULT_API_URL = "";
 const DEFAULT_REFRESH_INTERVAL = 30;
 const DEFAULT_MAX_ARRIVALS = 10;
+const DEFAULT_ICON = "mdi:bus";
 
 class TfiGtfsCardEditor extends LitElement {
     static properties = {


### PR DESCRIPTION
When installed in a docker installation the plugin bails out with a missing variable error